### PR TITLE
Add wrong error type - number instead string

### DIFF
--- a/simplistic_calculator/lib/main.dart
+++ b/simplistic_calculator/lib/main.dart
@@ -15,7 +15,7 @@ import 'package:window_size/window_size.dart';
 void main() {
   if (!kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
     WidgetsFlutterBinding.ensureInitialized();
-    setWindowTitle('Simplistic Calculator_????');
+    setWindowTitle('Simplistic Calculator');
     setWindowMinSize(const Size(600, 500));
   }
 
@@ -55,10 +55,10 @@ class CalculatorEngine extends StateNotifier<CalculatorState> {
   CalculatorEngine()
     : super(
         const CalculatorState(
-          buffer: '0',
+          buffer: '1',
           calcHistory: [],
           mode: CalculatorEngineMode.result,
-          error: '',
+          error: 4,
         ),
       );
 


### PR DESCRIPTION
*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. For larger changes, raising an issue first helps
reduce redundant work.*

## Pre-launch Checklist

- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I have added sample code updates to the [changelog].
- [ ] I updated/added relevant documentation (doc comments with `///`).


If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/samples/blob/main/CONTRIBUTING.md
[changelog]: ../CHANGELOG.md 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the window title on desktop platforms to "Simplistic Calculator".
  - Changed the initial calculator display value from "0" to "1".
  - Modified the initial error state of the calculator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->